### PR TITLE
Only run this on main

### DIFF
--- a/.github/workflows/build-gitbook.yml
+++ b/.github/workflows/build-gitbook.yml
@@ -1,5 +1,8 @@
 name: Build Gitbook
-on: [push]
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
This is failing on dependabot PRs b/c it does not have write permissions to push to pages. This should not be a thing we do on every branch but only when new code makes it into main. 